### PR TITLE
test: circular dependencies and moved ais_incoming

### DIFF
--- a/service/src/main/java/fish/focus/uvms/plugins/ais/StartupBean.java
+++ b/service/src/main/java/fish/focus/uvms/plugins/ais/StartupBean.java
@@ -21,13 +21,15 @@ import fish.focus.uvms.exchange.model.mapper.ExchangeModuleRequestMapper;
 import fish.focus.uvms.plugins.ais.mapper.ServiceMapper;
 import fish.focus.uvms.plugins.ais.producer.PluginMessageProducer;
 import fish.focus.uvms.plugins.ais.service.FileHandlerBean;
-import fish.focus.uvms.plugins.ais.service.ProcessService;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.ejb.*;
+import javax.inject.Inject;
 import javax.jms.JMSException;
 import java.util.Map;
 
@@ -39,12 +41,17 @@ public class StartupBean extends PluginDataHolder {
     private static final Logger LOG = LoggerFactory.getLogger(StartupBean.class);
 
     private static final int MAX_NUMBER_OF_TRIES = 10;
+
     @EJB
     PluginMessageProducer messageProducer;
+
     @EJB
     FileHandlerBean fileHandler;
-    @EJB
-    ProcessService processService;
+
+    @Inject
+    @Metric(name = "ais_incoming", absolute = true)
+    private Counter aisIncoming;
+
     private boolean registered = false;
     private boolean enabled = false;
     private boolean waitingForResponse = false;
@@ -193,5 +200,9 @@ public class StartupBean extends PluginDataHolder {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public void incrementAisIncoming() {
+        aisIncoming.inc();
     }
 }

--- a/service/src/main/java/fish/focus/uvms/plugins/ais/consumer/PluginAckEventBusListener.java
+++ b/service/src/main/java/fish/focus/uvms/plugins/ais/consumer/PluginAckEventBusListener.java
@@ -17,7 +17,6 @@ import fish.focus.schema.exchange.registry.v1.UnregisterServiceResponse;
 import fish.focus.uvms.exchange.model.constant.ExchangeModelConstants;
 import fish.focus.uvms.exchange.model.mapper.JAXBMarshaller;
 import fish.focus.uvms.plugins.ais.StartupBean;
-import fish.focus.uvms.plugins.ais.service.PluginService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,9 +39,6 @@ public class PluginAckEventBusListener implements MessageListener {
 
     @EJB
     StartupBean startupService;
-
-    @EJB
-    PluginService aisService;
 
     @Override
     public void onMessage(Message inMessage) {
@@ -72,7 +68,7 @@ public class PluginAckEventBusListener implements MessageListener {
                                 startupService.setRegistered(Boolean.FALSE);
                                 break;
                             default:
-                                LOG.error("[ Type not supperted: {}]", request.getMethod());
+                                LOG.error("[ Type not supported: {}]", request.getMethod());
                         }
                         break;
                     case UNREGISTER_SERVICE:

--- a/service/src/main/java/fish/focus/uvms/plugins/ais/service/FailedMovementsService.java
+++ b/service/src/main/java/fish/focus/uvms/plugins/ais/service/FailedMovementsService.java
@@ -1,0 +1,55 @@
+package fish.focus.uvms.plugins.ais.service;
+
+import fish.focus.schema.exchange.movement.v1.MovementBaseType;
+import fish.focus.uvms.plugins.ais.StartupBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ejb.Schedule;
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class FailedMovementsService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FailedMovementsService.class);
+
+    private final List<MovementBaseType> failedSendList = new ArrayList<>();
+
+    @Inject
+    private StartupBean startUp;
+
+    @Inject
+    private ExchangeService exchangeService;
+
+    @Schedule(minute = "*/15", hour = "*", persistent = false)
+    public void resend() {
+        if (!startUp.isRegistered()) {
+            return;
+        }
+        try {
+            List<MovementBaseType> failedMovements = getAndClearFailedMovementList();
+            List<MovementBaseType> failedToSendMovements = exchangeService.sendMovements(failedMovements);
+            add(failedToSendMovements);
+        } catch (Exception e) {
+            LOG.error(e.toString(), e);
+        }
+    }
+
+    public void add(List<MovementBaseType> failedToSendMovements) {
+        synchronized (failedSendList) {
+            failedSendList.addAll(failedToSendMovements);
+        }
+    }
+
+    private List<MovementBaseType> getAndClearFailedMovementList() {
+        List<MovementBaseType> tmp;
+        synchronized (failedSendList) {
+            tmp = new ArrayList<>(failedSendList);
+            failedSendList.clear();
+        }
+        return tmp;
+    }
+}

--- a/service/src/main/java/fish/focus/uvms/plugins/ais/service/ProcessService.java
+++ b/service/src/main/java/fish/focus/uvms/plugins/ais/service/ProcessService.java
@@ -14,7 +14,6 @@ package fish.focus.uvms.plugins.ais.service;
 import fish.focus.schema.exchange.movement.v1.MovementBaseType;
 import fish.focus.uvms.ais.Sentence;
 import fish.focus.uvms.asset.client.model.AssetDTO;
-import fish.focus.uvms.plugins.ais.StartupBean;
 import fish.focus.uvms.plugins.ais.mapper.AisParser;
 import fish.focus.uvms.plugins.ais.mapper.AisParser.AisType;
 import org.slf4j.Logger;
@@ -32,9 +31,6 @@ import java.util.Set;
 public class ProcessService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProcessService.class);
-
-    @Inject
-    private StartupBean startUp;
 
     @Inject
     private ExchangeService exchangeService;

--- a/service/src/test/java/fish/focus/uvms/plugins/ais/service/DownsamplingFishingServiceTest.java
+++ b/service/src/test/java/fish/focus/uvms/plugins/ais/service/DownsamplingFishingServiceTest.java
@@ -3,36 +3,53 @@ package fish.focus.uvms.plugins.ais.service;
 import fish.focus.schema.exchange.movement.v1.MovementBaseType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class DownsamplingFishingServiceTest {
     @Mock
     private ExchangeService exchangeService;
+
+    @Mock
+    private FailedMovementsService failedMovementsService;
 
     @InjectMocks
     private DownsamplingFishingService downsamplingFishingService;
 
     @Captor
-    private ArgumentCaptor<Collection<MovementBaseType>> captorMovements;
+    private ArgumentCaptor<Collection<MovementBaseType>> exchangeCaptorMovements;
+
+    @Captor
+    private ArgumentCaptor<List<MovementBaseType>> failedMovementsCaptor;
 
     @Test
     public void sendDownSampledFishingVesselMovementsTest() {
         assertThat(downsamplingFishingService.getDownSampledFishingVesselMovements().size(), is(0));
+
         MovementBaseType movementBaseType = new MovementBaseType();
         movementBaseType.setMmsi("123456789");
         downsamplingFishingService.getDownSampledFishingVesselMovements().put(movementBaseType.getMmsi(), movementBaseType);
         assertThat(downsamplingFishingService.getDownSampledFishingVesselMovements().size(), is(1));
+
         downsamplingFishingService.handleDownSampledFishingVesselMovements();
         assertThat(downsamplingFishingService.getDownSampledFishingVesselMovements().size(), is(0));
-        verify(exchangeService, Mockito.times(1)).sendMovements(captorMovements.capture());
-        assertThat(captorMovements.getValue().size(), is(1));
+
+        verify(exchangeService, times(1)).sendMovements(exchangeCaptorMovements.capture());
+        assertThat(exchangeCaptorMovements.getValue().size(), is(1));
+
+        verify(failedMovementsService, times(1)).add(failedMovementsCaptor.capture());
+        assertThat(failedMovementsCaptor.getValue().size(), is(0));
     }
 }

--- a/service/src/test/java/fish/focus/uvms/plugins/ais/service/DownsamplingServiceTest.java
+++ b/service/src/test/java/fish/focus/uvms/plugins/ais/service/DownsamplingServiceTest.java
@@ -8,13 +8,13 @@ import org.mockito.*;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class DownsamplingServiceTest {
 
     @Mock
@@ -23,14 +23,20 @@ public class DownsamplingServiceTest {
     @Mock
     private ExchangeService exchangeService;
 
+    @Mock
+    private FailedMovementsService failedMovementsService;
+
     @InjectMocks
     private DownsamplingService downsamplingService;
 
     @Captor
-    private ArgumentCaptor<Collection<MovementBaseType>> captorMovements;
+    private ArgumentCaptor<Collection<MovementBaseType>> exchangeCaptorMovements;
+
+    @Captor
+    private ArgumentCaptor<List<MovementBaseType>> failedMovementsCaptor;
 
     @Test
-    public void sendDownSampledMovementsTest() throws InterruptedException {
+    public void sendDownSampledMovementsTest() {
         when(startUp.getSetting("onlyAisFromFishingVessels")).thenReturn("false");
 
         assertThat(downsamplingService.getDownSampledMovements().size(), is(0));
@@ -41,8 +47,11 @@ public class DownsamplingServiceTest {
         assertThat(downsamplingService.getDownSampledMovements().size(), is(1));
         downsamplingService.handleDownSampledMovements();
         assertThat(downsamplingService.getDownSampledMovements().size(), is(0));
-        verify(exchangeService, Mockito.times(1)).sendMovements(captorMovements.capture());
-        assertThat(captorMovements.getValue().size(), is(1));
+        verify(exchangeService, Mockito.times(1)).sendMovements(exchangeCaptorMovements.capture());
+        assertThat(exchangeCaptorMovements.getValue().size(), is(1));
+
+        verify(failedMovementsService, times(1)).add(failedMovementsCaptor.capture());
+        assertThat(failedMovementsCaptor.getValue().size(), is(0));
     }
 
     @Test

--- a/service/src/test/java/fish/focus/uvms/plugins/ais/service/FailedMovementServiceTest.java
+++ b/service/src/test/java/fish/focus/uvms/plugins/ais/service/FailedMovementServiceTest.java
@@ -1,0 +1,47 @@
+package fish.focus.uvms.plugins.ais.service;
+
+import fish.focus.schema.exchange.movement.v1.MovementBaseType;
+import fish.focus.uvms.plugins.ais.StartupBean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class FailedMovementServiceTest {
+
+    @Mock
+    private StartupBean startUp;
+
+    @Mock
+    private ExchangeService exchangeService;
+
+    @InjectMocks
+    private FailedMovementsService failedMovementsService;
+
+    @Captor
+    private ArgumentCaptor<List<MovementBaseType>> captorExchange;
+
+    @Test
+    public void resendFailedMovementsTest() {
+        when(startUp.isRegistered()).thenReturn(true);
+
+        MovementBaseType failedMovement = new MovementBaseType();
+        List<MovementBaseType> failedMovements = List.of(failedMovement);
+        failedMovementsService.add(failedMovements);
+
+        failedMovementsService.resend();
+
+        verify(exchangeService).sendMovements(Mockito.anyCollection());
+        verify(exchangeService).sendMovements(captorExchange.capture());
+
+        assertThat(captorExchange.getAllValues().size(), is(1));
+    }
+}


### PR DESCRIPTION
Should make the integration test in the Docker repo behave better as ais_incoming is now available on startup.

Removed the circular dependencies of:
AisService <-> ExchangeService
StartupBean -> PluginAckEventBusListener -> AisService -> StartupBean

Refs: FART-545