### PR TITLE
test: service tests should work better on windows

### DIFF
--- a/service/src/main/java/fish/focus/uvms/plugins/ais/service/AisService.java
+++ b/service/src/main/java/fish/focus/uvms/plugins/ais/service/AisService.java
@@ -216,9 +216,11 @@ public class AisService {
             backOffTime = shortBackOffTime;
         }
 
-        boolean shouldTryReconnect = lastConnectionAttempt.plus(backOffTime, backOffUnit).isBefore(now);
-        LOG.info("last connection attempt was at {} with {} connection attempts. Should try to connect = {}",
-                lastConnectionAttempt, numberOfReconnectAttempts, shouldTryReconnect);
+        Instant earliestNextAttempt = lastConnectionAttempt.plus(backOffTime, backOffUnit);
+        // is before or equal
+        boolean shouldTryReconnect = now.isAfter(earliestNextAttempt);
+        LOG.info("{} connection attempts. Last attempt at {}. Earliest next attempt at {}. Now is {}. Reconnect now = {}",
+                numberOfReconnectAttempts, lastConnectionAttempt, earliestNextAttempt, now, shouldTryReconnect);
         return shouldTryReconnect;
     }
 

--- a/service/src/test/java/fish/focus/uvms/plugins/ais/service/AisServiceTest.java
+++ b/service/src/test/java/fish/focus/uvms/plugins/ais/service/AisServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.enterprise.concurrent.ManagedExecutorService;
@@ -16,7 +17,6 @@ import javax.resource.ResourceException;
 import java.util.List;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
-import static java.time.temporal.ChronoUnit.NANOS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.with;
@@ -49,13 +49,38 @@ public class AisServiceTest {
     @InjectMocks
     private AisService aisService;
 
+    private int numberOfGeneratedReconnectAnswers = 0;
+    private final List<Boolean> reconnectAnswersForBackOffs = List.of(
+            // init
+            false,
+            // connectAndRetrieve -> isConnectionDown
+            // Should have a "live" connection since these tests are about a
+            // connection not receiving data while still open
+            true, true, true
+    );
+
+
     @Before
     public void setupMocks() {
+        numberOfGeneratedReconnectAnswers = 0;
+
         when(startUp.isEnabled()).thenReturn(true);
         when(startUp.getSetting("HOST")).thenReturn("127.0.0.0");
         when(startUp.getSetting("PORT")).thenReturn("0");
         when(startUp.getSetting("USERNAME")).thenReturn("myusername");
         when(startUp.getSetting("PASSWORD")).thenReturn("mypassword");
+    }
+
+    private boolean generateConnectionAnswersForBackOffTests(InvocationOnMock input) {
+        // mimics internal state in AisService
+
+        numberOfGeneratedReconnectAnswers++;
+        if (numberOfGeneratedReconnectAnswers == 25) {
+            // need to skip the init in the 25th run since it should be in a "lockout" period then
+            numberOfGeneratedReconnectAnswers++;
+        }
+
+        return reconnectAnswersForBackOffs.get((numberOfGeneratedReconnectAnswers - 1) % 4);
     }
 
     // White-box testing the reconnect functionality
@@ -64,7 +89,7 @@ public class AisServiceTest {
     public void shouldNotReconnectDuringShortBackOffTime() throws ResourceException {
         AISConnection connectionMock = mock(AISConnection.class);
         when(connectionMock.getSentences()).thenReturn(List.of());
-        when(connectionMock.isOpen()).thenReturn(false, true, true, true, false);
+        when(connectionMock.isOpen()).thenAnswer(this::generateConnectionAnswersForBackOffTests);
         when(factory.getConnection()).thenReturn(connectionMock);
 
         aisService.init();
@@ -79,7 +104,7 @@ public class AisServiceTest {
     public void shouldReconnectWhenNoMessagesOnFirstTryWithNoBackOffTime() throws ResourceException {
         AISConnection connectionMock = mock(AISConnection.class);
         when(connectionMock.getSentences()).thenReturn(List.of());
-        when(connectionMock.isOpen()).thenReturn(false, true, true, true, false);
+        when(connectionMock.isOpen()).thenAnswer(this::generateConnectionAnswersForBackOffTests);
         when(factory.getConnection()).thenReturn(connectionMock);
 
         aisService.shortBackOffTime = 0;
@@ -96,39 +121,12 @@ public class AisServiceTest {
     public void shouldReconnectWhenNoMessagesOnSixthTryAfterLongBackOffTime() throws ResourceException {
         AISConnection connectionMock = mock(AISConnection.class);
         when(connectionMock.getSentences()).thenReturn(List.of());
-        // mimics internal state in AisService
-        when(connectionMock.isOpen()).thenReturn(false, // init from this method
-
-                // 1 connectAndRetrieve
-                true, true, true, // isConnectionDown
-                false, // init
-
-                // 2 connectAndRetrieve
-                true, true, true, // isConnectionDown
-                false, // init
-
-                // 3 connectAndRetrieve
-                true, true, true, // isConnectionDown
-                false, // init
-
-                // 4 connectAndRetrieve
-                true, true, true, // isConnectionDown
-                false, // init
-
-                // 5 connectAndRetrieve
-                true, true, true, // isConnectionDown
-                false, // init
-
-                // 6 connectAndRetrieve
-                true, true, true, // isConnectionDown
-
-                // 7 connectAndRetrieve
-                true, true, true, // isConnectionDown
-                false // init
-        );
+        when(connectionMock.isOpen()).thenAnswer(this::generateConnectionAnswersForBackOffTests);
         when(factory.getConnection()).thenReturn(connectionMock);
 
         aisService.shortBackOffTime = 0;
+        // windows might have time resolution in 10s of millis?
+        aisService.longBackOffTime = 50;
         aisService.backOffUnit = MILLIS;
 
         aisService.init();
@@ -138,11 +136,15 @@ public class AisServiceTest {
         }
 
         // Need to wait for the above lockout period to pass before running again
-        with().pollDelay(20, MILLISECONDS).await().atMost(2, SECONDS)
-                .untilAsserted(() -> aisService.connectAndRetrieve());
-
-        verify(connectionMock, times(7)).open(anyString(), anyInt(), anyString(), anyString());
-        verify(connectionMock, times(6)).close();
+        with()
+                .pollDelay(100, MILLISECONDS)
+                .await()
+                .atMost(1, SECONDS)
+                .untilAsserted(() -> {
+                    aisService.connectAndRetrieve();
+                    verify(connectionMock, times(7)).open(anyString(), anyInt(), anyString(), anyString());
+                    verify(connectionMock, times(6)).close();
+                });
     }
 
     @Test


### PR DESCRIPTION
Seems windows has less time precision than linux so need to account for that in tests.

Precision has been increased in JDK > 15.