### PR TITLE
test: fixes windows timing issues

### DIFF
--- a/service/src/main/java/fish/focus/uvms/plugins/ais/service/AisService.java
+++ b/service/src/main/java/fish/focus/uvms/plugins/ais/service/AisService.java
@@ -217,8 +217,7 @@ public class AisService {
         }
 
         Instant earliestNextAttempt = lastConnectionAttempt.plus(backOffTime, backOffUnit);
-        // is before or equal
-        boolean shouldTryReconnect = now.isAfter(earliestNextAttempt);
+        boolean shouldTryReconnect = !now.isBefore(earliestNextAttempt);
         LOG.info("{} connection attempts. Last attempt at {}. Earliest next attempt at {}. Now is {}. Reconnect now = {}",
                 numberOfReconnectAttempts, lastConnectionAttempt, earliestNextAttempt, now, shouldTryReconnect);
         return shouldTryReconnect;


### PR DESCRIPTION
Since the windows system clock has millisecond resolution multiple invocations of Instant.now() might yield the same "instant in time" when in reality time has passed between the invocations.

See https://bugs.openjdk.org/browse/JDK-8180466 for more information.